### PR TITLE
Fix/add iam policy

### DIFF
--- a/dreamkast_infra/dev/eks.tf
+++ b/dreamkast_infra/dev/eks.tf
@@ -171,7 +171,7 @@ module "eks" {
 }
 
 
-resource "aws_iam_policy" "additional" {
+resource "aws_iam_policy" "eks_additional_policy" {
   name = "${var.cluster_name}-additional-policy"
 
   policy = jsonencode({

--- a/dreamkast_infra/dev/eks.tf
+++ b/dreamkast_infra/dev/eks.tf
@@ -35,6 +35,10 @@ module "eks" {
     }
   }
 
+  iam_role_additional_policies = {
+    additional = aws_iam_policy.eks_additional_policy.arn
+  }
+
   vpc_id                   = module.vpc.vpc_id
   subnet_ids               = module.vpc.private_subnets
   control_plane_subnet_ids = module.vpc.intra_subnets
@@ -164,6 +168,24 @@ module "eks" {
   ]
 
   tags = { "karpenter.sh/discovery" = "${var.cluster_name}" }
+}
+
+
+resource "aws_iam_policy" "additional" {
+  name = "${var.cluster_name}-additional-policy"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = [
+          "route53:ListHostedZonesByName",
+        ]
+        Effect   = "Allow"
+        Resource = "*"
+      },
+    ]
+  })
 }
 
 

--- a/dreamkast_infra/dev/eks.tf
+++ b/dreamkast_infra/dev/eks.tf
@@ -180,6 +180,13 @@ resource "aws_iam_policy" "additional" {
       {
         Action = [
           "route53:ListHostedZonesByName",
+          "ecr:GetAuthorizationToken",
+          "ecr:BatchCheckLayerAvailability",
+          "ecr:GetDownloadUrlForLayer",
+          "ecr:GetRepositoryPolicy",
+          "ecr:DescribeRepositories",
+          "ecr:ListImages",
+          "ecr:BatchGetImage",
         ]
         Effect   = "Allow"
         Resource = "*"


### PR DESCRIPTION
下記エラの修正 @ wildcard-dev-cloudnativedays
Error presenting challenge: failed to determine Route 53 hosted zone ID: AccessDenied: User: arn:aws:sts::607167088920:assumed-role/dk-us-mng-spot-eks-node-group-20230304051205659500000004/i-097a69ad0bd9817d9 is not authorized to perform: route53:ListHostedZonesByName because no identity-based policy allows the route53:ListHostedZonesByName action