### PR TITLE
Fix instance type xlarge

### DIFF
--- a/dreamkast_infra/dev/eks.tf
+++ b/dreamkast_infra/dev/eks.tf
@@ -120,6 +120,10 @@ module "eks" {
 
       capacity_type = "SPOT"
 
+      update_config = {
+        max_unavailable = 1
+      }
+
       # We are using the IRSA created below for permissions
       # However, we have to deploy with the policy attached FIRST (when creating a fresh cluster)
       # and then turn this off after the cluster/node group is created. Without this initial policy,
@@ -128,16 +132,16 @@ module "eks" {
       iam_role_attach_cni_policy = true
 
       iam_role_additional_policies = {
-        additional = aws_iam_policy.eks_additional_policy.arn,
+        additional                         = aws_iam_policy.eks_additional_policy.arn,
         AmazonEC2ContainerRegistryReadOnly = data.aws_iam_policy.AmazonEC2ContainerRegistryReadOnly.arn,
-        AmazonEKSWorkerNodePolicy = data.aws_iam_policy.AmazonEKSWorkerNodePolicy.arn,
-        AmazonEKS_CNI_Policy = data.aws_iam_policy.AmazonEKS_CNI_Policy.arn,
-        AWSElementalMediaLiveFullAccess = data.aws_iam_policy.AWSElementalMediaLiveFullAccess.arn,
-        AmazonS3FullAccess = data.aws_iam_policy.AmazonS3FullAccess.arn,
-        AmazonSESFullAccess = data.aws_iam_policy.AmazonSESFullAccess.arn,
-        AmazonSSMManagedInstanceCore = data.aws_iam_policy.AmazonSSMManagedInstanceCore.arn,
-        AmazonSQSFullAccess = data.aws_iam_policy.AmazonSQSFullAccess.arn,
-        CloudWatchAgentServerPolicy = data.aws_iam_policy.CloudWatchAgentServerPolicy.arn,
+        AmazonEKSWorkerNodePolicy          = data.aws_iam_policy.AmazonEKSWorkerNodePolicy.arn,
+        AmazonEKS_CNI_Policy               = data.aws_iam_policy.AmazonEKS_CNI_Policy.arn,
+        AWSElementalMediaLiveFullAccess    = data.aws_iam_policy.AWSElementalMediaLiveFullAccess.arn,
+        AmazonS3FullAccess                 = data.aws_iam_policy.AmazonS3FullAccess.arn,
+        AmazonSESFullAccess                = data.aws_iam_policy.AmazonSESFullAccess.arn,
+        AmazonSSMManagedInstanceCore       = data.aws_iam_policy.AmazonSSMManagedInstanceCore.arn,
+        AmazonSQSFullAccess                = data.aws_iam_policy.AmazonSQSFullAccess.arn,
+        CloudWatchAgentServerPolicy        = data.aws_iam_policy.CloudWatchAgentServerPolicy.arn,
         CloudWatchSyntheticsReadOnlyAccess = data.aws_iam_policy.CloudWatchSyntheticsReadOnlyAccess.arn,
         AWSElementalMediaPackageFullAccess = data.aws_iam_policy.AWSElementalMediaPackageFullAccess.arn
       }

--- a/dreamkast_infra/dev/eks.tf
+++ b/dreamkast_infra/dev/eks.tf
@@ -112,7 +112,7 @@ module "eks" {
 
       platform       = "bottlerocket"
       ami_type       = "BOTTLEROCKET_x86_64"
-      instance_types = ["m6i.large", "m6a.large", "m5.large", "m5a.large", "t3.large", "t3a.large"]
+      instance_types = ["m6i.xlarge", "m6a.xlarge", "m5.xlarge", "m5a.xlarge", "t3.xlarge", "t3a.xlarge"]
 
       # Graviton対応時にコメントアウト解除
       # ami_type = "BOTTLEROCKET_ARM_64"

--- a/dreamkast_infra/dev/variables.tf
+++ b/dreamkast_infra/dev/variables.tf
@@ -24,7 +24,7 @@ variable "cluster_version" {
 }
 
 variable "node_desired_size" {
-  default = 3
+  default = 4
 }
 
 variable "node_max_size" {


### PR DESCRIPTION
インスタンスタイプをlargeにしたところ必要ノード数が2倍以上になって逆に高くなってしまいました。
falco-exporterなどノード毎に動くリソースでだいぶ消費してしまってCPU2コアでは足りないようです。
なので元に戻します。