### PR TITLE
Update client.tf for auth0

### DIFF
--- a/auth0/.terraform.lock.hcl
+++ b/auth0/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/auth0/auth0" {
   version     = "0.44.1"
   constraints = "~> 0.44.1"
   hashes = [
+    "h1:vqAd3Pr46dr99sG0yLeiLWU7ZmC2aOk3x3rkdPz0x7k=",
     "h1:y8qUgBruGkfhJwRtdXFb6RrlCWFUUDFS4zYxxh0J9Sc=",
     "zh:005071b2e87eb8b30d96c0ebb8a642c53368916cf331647a91deb865935f60ce",
     "zh:0d0f8c4d09392aceb85922a44cf8e21700c85bd6f14d77055a730d87e5c3c7e1",

--- a/auth0/client.tf
+++ b/auth0/client.tf
@@ -1,7 +1,14 @@
 resource "auth0_client" "tfer--0cWWdpGt4CpWjHJ9QIHtPm5GrJLS25lz_Dreamkast-0020-UI-0020---0020-Review" {
-  allowed_logout_urls                 = ["http://localhost:8080", "https://*.dev.cloudnativedays.jp"]
-  app_type                            = "spa"
-  callbacks                           = ["http://*.dev.cloudnativedays.jp/cicd2023/ui", "http://*.dev.cloudnativedays.jp/cndt2022/ui", "http://localhost:3001/cicd2023/ui", "http://localhost:3001/cndt2022/ui", "http://localhost:3001/discussionboard", "http://localhost:8080/cicd2023/ui", "http://localhost:8080/cndt2022/ui", "https://*.dev.cloudnativedays.jp/cicd2023/ui", "https://*.dev.cloudnativedays.jp/cndt2022/ui"]
+  allowed_logout_urls = ["http://localhost:8080", "https://*.dev.cloudnativedays.jp"]
+  app_type            = "spa"
+  callbacks = [
+    "http://*.dev.cloudnativedays.jp/cicd2023/ui",
+    "http://*.dev.cloudnativedays.jp/cndt2022/ui",
+    "http://localhost:3001/discussionboard",
+    "http://localhost:3001/cndf2023/ui",
+    "https://*.dev.cloudnativedays.jp/cicd2023/ui",
+    "https://*.dev.cloudnativedays.jp/cndt2022/ui",
+  ]
   cross_origin_auth                   = "false"
   custom_login_page_on                = "true"
   grant_types                         = ["authorization_code", "refresh_token"]
@@ -372,9 +379,14 @@ resource "auth0_client" "tfer--Ivee5RoyvPB8PcUdiLZqPnGZSmixkK5N_Nextcloud" {
 }
 
 resource "auth0_client" "tfer--JxqrUDloZhPPWKflAQXlmPJgxrI1d5ms_Dreamkast-0020-UI" {
-  allowed_logout_urls                 = ["https://event.cloudnativedays.jp"]
-  app_type                            = "spa"
-  callbacks                           = ["https://event.cloudnativedays.jp/cicd2023/ui", "https://event.cloudnativedays.jp/cndt2022/ui", "https://event.cloudnativedays.jp/cnsec2022/ui"]
+  allowed_logout_urls = ["https://event.cloudnativedays.jp"]
+  app_type            = "spa"
+  callbacks = [
+    "https://event.cloudnativedays.jp/cicd2023/ui",
+    "https://event.cloudnativedays.jp/cndf2023/ui",
+    "https://event.cloudnativedays.jp/cndt2022/ui",
+    "https://event.cloudnativedays.jp/cnsec2022/ui",
+  ]
   cross_origin_auth                   = "false"
   custom_login_page_on                = "true"
   grant_types                         = ["authorization_code", "refresh_token"]
@@ -526,9 +538,14 @@ resource "auth0_client" "tfer--QnXQCFIndJASnVUy7dO8RAd9neGeFnP6_Dreamkast-0020-A
 }
 
 resource "auth0_client" "tfer--TPeiKSZzmH2JZJPybE290kypTUrWClTk_Dreamkast-0020-UI-0020---0020-Staging" {
-  allowed_logout_urls                 = ["https://staging.dev.cloudnativedays.jp"]
-  app_type                            = "spa"
-  callbacks                           = ["http://localhost:3001/cicd2023/ui", "http://localhost:8080/cicd2023/ui", "https://staging.dev.cloudnativedays.jp/cicd2023/ui", "https://staging.dev.cloudnativedays.jp/cndt2022/ui", "https://staging.dev.cloudnativedays.jp/cnsec2022/ui"]
+  allowed_logout_urls = ["https://staging.dev.cloudnativedays.jp"]
+  app_type            = "spa"
+  callbacks = [
+    "https://staging.dev.cloudnativedays.jp/cicd2023/ui",
+    "https://staging.dev.cloudnativedays.jp/cndf2023/ui",
+    "https://staging.dev.cloudnativedays.jp/cndt2022/ui",
+    "https://staging.dev.cloudnativedays.jp/cnsec2022/ui",
+  ]
   cross_origin_auth                   = "false"
   custom_login_page_on                = "true"
   grant_types                         = ["authorization_code", "refresh_token"]
@@ -569,7 +586,7 @@ resource "auth0_client" "tfer--TPeiKSZzmH2JZJPybE290kypTUrWClTk_Dreamkast-0020-U
   sso                        = "false"
   sso_disabled               = "false"
   token_endpoint_auth_method = "none"
-  web_origins                = ["http://localhost:3001/cicd2023/ui", "https://staging.dev.cloudnativedays.jp"]
+  web_origins                = ["http://localhost:3001/cndf2023/ui", "https://staging.dev.cloudnativedays.jp"]
 }
 
 resource "auth0_client" "tfer--VcE2MiC04c9ofKhRf3jplPFFtUyyznaX_All-0020-Applications" {


### PR DESCRIPTION
- 変更点
  - ローカル開発向けの情報を更新しました
    - 古いイベントに関するものを削除し、CNDF2023の設定を追加しました
    - callbacksに`http://localhost:8080/cndf2023/ui`を追加するか悩みましたが、nginx経由せず直アクセスするようになっているみたいだったので対応は見送りました
      - https://cloudnativedays.slack.com/archives/C015CN1PQ06/p1688889751089199?thread_ts=1688878036.508249&cid=C015CN1PQ06

- terraform planの結果
  - https://app.terraform.io/app/cloudnativedaysjp/workspaces/auth0/runs/run-azkxYFnCMLVZeDZk
  - CNDF2023に関するものは手動で設定していたので、差分として出てきてないですー
