### PR TITLE
update the upper limit of number of Nodes on EKS node group

### DIFF
--- a/dreamkast_infra/prod/variables.tf
+++ b/dreamkast_infra/prod/variables.tf
@@ -38,7 +38,7 @@ variable "node_desired_size" {
 }
 
 variable "node_max_size" {
-  default = 7
+  default = 10
 }
 
 variable "node_min_size" {

--- a/dreamkast_infra/prod/variables.tf
+++ b/dreamkast_infra/prod/variables.tf
@@ -38,7 +38,7 @@ variable "node_desired_size" {
 }
 
 variable "node_max_size" {
-  default = 5
+  default = 7
 }
 
 variable "node_min_size" {


### PR DESCRIPTION
dreamkast-prod EKS の Node auto scale の upper limit を 5->7 に更新しました。
会期当日 dk の各 Pod の minReplicas が 2 -> 10 に増えるので、それの対応です。