### PR TITLE
Update health check endpoint for sentry

### DIFF
--- a/sakuracloud/monitoring.tf
+++ b/sakuracloud/monitoring.tf
@@ -147,7 +147,7 @@ resource "sakuracloud_simple_monitor" "sentry" {
   health_check {
     protocol        = "https"
     port            = 443
-    path            = "/_health/"
+    path            = "/"
     status          = "200"
     host_header     = "sentry.cloudnativedays.jp"
     sni             = true


### PR DESCRIPTION
 /_health can't notice the failure of internal components (Kafka, etc.)