### PR TITLE
Istio ambient mesh/Kiali用に追加のポートを開ける

### DIFF
--- a/handson/main.tf
+++ b/handson/main.tf
@@ -121,6 +121,15 @@ resource "sakuracloud_packet_filter_rules" "handson_rules" {
     destination_port = "18443"
   }
 
+  expression {
+    protocol         = "tcp"
+    destination_port = "28080"
+  }
+
+  expression {
+    protocol         = "tcp"
+    destination_port = "28443"
+  }
 
   expression {
     protocol         = "udp"


### PR DESCRIPTION
Istio ambient meshチャプターで使用するKiali用に追加のポートを開けるためのpull requestです。
このチャプターではCNIの兼ね合いで新規でkind clusterを立てる必要があり、準じてKiali用の外部接続用ポートも必要になるため(port 80は既存K8s clusterで使用済み)ご依頼させていただきました。