### PR TITLE
ArchiveのS3にライフサイクルルールを設定

### DIFF
--- a/dreamkast_infra/stg/s3.tf
+++ b/dreamkast_infra/stg/s3.tf
@@ -35,3 +35,22 @@ resource "aws_s3_bucket_lifecycle_configuration" "bucket_lifecycle" {
   }
 
 }
+
+
+# ------------------------------------------------------------#
+#  Archiveデータ削減のためのライフサイクル
+# ------------------------------------------------------------#
+data "aws_s3_bucket" "archive" {
+  bucket = "dreamkast-archive-stg"
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "archive" {
+  bucket = data.aws_s3_bucket.archive.id
+  rule {
+    id     = "ArchiveObjectRule"
+    status = "Enabled"
+    expiration {
+      expired_object_delete_marker = true
+    }
+  }
+}


### PR DESCRIPTION
[こちら](https://www.notion.so/cloudnativedays/2024-03-24-a4d4500ecc834a9ba93ce59e72f20518?pvs=4)の議事録の通りdreamkast-archive-stgの削除されたオブジェクトを削除するルールを設定

[ライフサイクルルールの参考記事](https://dev.classmethod.jp/articles/3minutes-s3-versioning-lifecycle/)