### PR TITLE
Reupgrade sentry vm cpu spec

### DIFF
--- a/sakuracloud/sentry.tf
+++ b/sakuracloud/sentry.tf
@@ -12,7 +12,7 @@ resource "sakuracloud_server" "sentry" {
     sakuracloud_disk.sentry_boot.id,
     sakuracloud_disk.sentry_docker_volume.id,
   ]
-  core        = 12
+  core        = 20
   memory      = 32
   description = "Sentry server"
   tags        = ["app=sentry", "stage=production", "starred"]


### PR DESCRIPTION
- Consumerは8コア -> 12コアで1.1k/minのスループット向上（7.94k/min -> 9.04k/min）
- Producer側は、12.3k/minでメッセージ送信をしているので、本来であれば24コアくらいまで上げないとダメな気がするが20コアまでしか上げられないので、このような対応になっています