### PR TITLE
switch is referenced by data

### DIFF
--- a/o11y_infra/stg/networking.tf
+++ b/o11y_infra/stg/networking.tf
@@ -1,7 +1,7 @@
-resource "sakuracloud_switch" "o11y" {
-  name        = "o11y-stg"
-  description = "switch for o11y staging"
-  tags        = ["o11y"]
+data "sakuracloud_switch" "o11y" {
+  filter {
+    names = ["sentry"]
+  }
 }
 
 resource "sakuracloud_packet_filter" "prometheus" {

--- a/o11y_infra/stg/servers.tf
+++ b/o11y_infra/stg/servers.tf
@@ -15,7 +15,7 @@ resource "sakuracloud_server" "prometheus" {
   }
 
   network_interface {
-    upstream = sakuracloud_switch.o11y.id
+    upstream = data.sakuracloud_switch.o11y.id
   }
 
   user_data = templatefile("./template/sentry-init.yaml", {
@@ -48,7 +48,7 @@ resource "sakuracloud_server" "loki" {
   }
 
   network_interface {
-    upstream = sakuracloud_switch.o11y.id
+    upstream = data.sakuracloud_switch.o11y.id
   }
 
   user_data = templatefile("./template/sentry-init.yaml", {
@@ -81,7 +81,7 @@ resource "sakuracloud_server" "grafana" {
   }
 
   network_interface {
-    upstream = sakuracloud_switch.o11y.id
+    upstream = data.sakuracloud_switch.o11y.id
   }
 
   user_data = templatefile("./template/sentry-init.yaml", {


### PR DESCRIPTION
> Error: creating SakuraCloud Switch is failed: Error in response: &iaas.APIErrorResponse{IsFatal:true, Serial:“”, Status:“409 Conflict”, ErrorCode:“limit_count_in_zone”, ErrorMessage:“要求を受け付けできません。ゾーン内リソース数上限により、リソースの割り当てに失敗しました。“}

- sakuraのクラウドで作成できるスイッチの数に上限があるので、o11yで使うスイッチは環境別で分けずに共有にする
- stg側のスイッチはprdのスイッチをdataリソースで参照する