### PR TITLE
rename o11y switch

### DIFF
--- a/o11y_infra/prd/networking.tf
+++ b/o11y_infra/prd/networking.tf
@@ -1,7 +1,7 @@
-resource "sakuracloud_switch" "sentry" {
-  name        = "sentry"
-  description = "sentry"
-  tags        = ["sentry"]
+resource "sakuracloud_switch" "o11y" {
+  name        = "o11y"
+  description = "o11y"
+  tags        = ["o11y"]
 }
 
 resource "sakuracloud_packet_filter" "o11y_stacks" {

--- a/o11y_infra/prd/servers.tf
+++ b/o11y_infra/prd/servers.tf
@@ -15,7 +15,7 @@ resource "sakuracloud_server" "sentry" {
   }
 
   network_interface {
-    upstream = sakuracloud_switch.sentry.id
+    upstream = sakuracloud_switch.o11y.id
   }
 
   user_data = templatefile("./template/sentry-init.yaml", {
@@ -48,7 +48,7 @@ resource "sakuracloud_server" "sentry_redis" {
   }
 
   network_interface {
-    upstream = sakuracloud_switch.sentry.id
+    upstream = sakuracloud_switch.o11y.id
   }
 
   user_data = templatefile("./template/sentry-init.yaml", {
@@ -81,7 +81,7 @@ resource "sakuracloud_server" "o11y_stacks" {
   }
 
   network_interface {
-    upstream = sakuracloud_switch.sentry.id
+    upstream = sakuracloud_switch.o11y.id
   }
 
   user_data = templatefile("./template/o11y-init.yaml", {

--- a/o11y_infra/stg/networking.tf
+++ b/o11y_infra/stg/networking.tf
@@ -1,6 +1,6 @@
 data "sakuracloud_switch" "o11y" {
   filter {
-    names = ["sentry"]
+    names = ["o11y"]
   }
 }
 


### PR DESCRIPTION
対応したこと

1. stateから sakuracloud_switch.sentry を削除 

```
terraform state rm sakuracloud_switch.sentry
```

2. switchのTerraformリソース名を変更

```
sakuracloud_switch.sentry => sakuracloud_switch.o11y
```

3. sakuracloud_switch.o11yに既存スイッチをimport

```
terraform import sakuracloud_switch.o11y <SwitchID>
```

planの差分

```
  ~ resource "sakuracloud_switch" "o11y" {
      ~ description = "sentry" -> "o11y"
        id          = "<SwitchID>"
      ~ name        = "sentry" -> "o11y"
      ~ tags        = [
          - "sentry",
          + "o11y",
        ]
        # (4 unchanged attributes hidden)
    }
```

- description, name, tagなどはTerraform applyで変更する
- stateを変更しているので #207 をapplyする前に本PRを取り込む
