### PR TITLE
setup for GHA to assume AWS IAM Role

### DIFF
--- a/github_actions_assume_aws_role/.terraform.lock.hcl
+++ b/github_actions_assume_aws_role/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.94.1"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:dYdnGlaCJONFyGk/t3Y4iJzQ8EiJr2DaDdZ/2JV5PZU=",
+    "zh:14fb41e50219660d5f02b977e6f786d8ce78766cce8c2f6b8131411b087ae945",
+    "zh:3bc5d12acd5e1a5f1cf78a7f05d0d63f988b57485e7d20c47e80a0b723a99d26",
+    "zh:4835e49377f80a37c6191a092f636e227a9f086e3cc3f0c9e1b554da8793cfe8",
+    "zh:605971275adae25096dca30a94e29931039133c667c1d9b38778a09594312964",
+    "zh:8ae46b4a9a67815facf59da0c56d74ef71bcc77ae79e8bfbac504fa43f267f8e",
+    "zh:913f3f371c3e6d1f040d6284406204b049977c13cb75aae71edb0ef8361da7dd",
+    "zh:91f85ae8c73932547ad7139ce0b047a6a7c7be2fd944e51db13231cc80ce6d8e",
+    "zh:96352ae4323ce137903b9fe879941f894a3ce9ef30df1018a0f29f285a448793",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9b51922c9201b1dc3d05b39f9972715db5f67297deee088793d02dea1832564b",
+    "zh:a689e82112aa71e15647b06502d5b585980cd9002c3cc8458f092e8c8a667696",
+    "zh:c3723fa3e6aff3c1cc0088bdcb1edee168fe60020f2f77161d135bf473f45ab2",
+    "zh:d6a2052b864dd394b01ad1bae32d0a7d257940ee47908d02df7fa7873981d619",
+    "zh:dda4c9c0406cc54ad8ee4f19173a32de7c6e73abb5a948ea0f342d567df26a1d",
+    "zh:f42e0fe592b97cbdf70612f0fbe2bab851835e2d1aaf8cbb87c3ab0f2c96bb27",
+  ]
+}

--- a/github_actions_assume_aws_role/main.tf
+++ b/github_actions_assume_aws_role/main.tf
@@ -1,0 +1,81 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+  cloud {
+    organization = "cloudnativedaysjp"
+
+    workspaces {
+      name = "github_actions_assume_aws_role"
+    }
+  }
+}
+
+provider "aws" {
+  region = "us-west-2"
+}
+
+
+resource "aws_iam_role" "github_actions" {
+  name               = "github-actions-dreamkast"
+  assume_role_policy = data.aws_iam_policy_document.github_actions.json
+  description        = "IAM Role for GitHub Actions OIDC"
+}
+
+locals {
+  allowed_github_repositories = [
+    "dreamkast",
+    "dreamkast-functions",
+    "dreamkast-ui",
+    "dreamkast-weaver",
+    "seaman",
+    #"website",  # website is maintained under ../website/
+  ]
+  github_org_name = "cloudnativedaysjp"
+  full_paths = [
+    for repo in local.allowed_github_repositories : "repo:${local.github_org_name}/${repo}:*"
+  ]
+}
+
+data "aws_iam_openid_connect_provider" "github_actions" {
+  arn = "arn:aws:iam::607167088920:oidc-provider/token.actions.githubusercontent.com"
+}
+
+data "aws_iam_policy_document" "github_actions" {
+  statement {
+    actions = [
+      "sts:AssumeRoleWithWebIdentity",
+    ]
+
+    principals {
+      type = "Federated"
+      identifiers = [
+        data.aws_iam_openid_connect_provider.github_actions.arn
+      ]
+    }
+
+    condition {
+      test     = "StringLike"
+      variable = "token.actions.githubusercontent.com:sub"
+      values   = local.full_paths
+    }
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "ecs" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonECS_FullAccess"
+  role       = aws_iam_role.github_actions.name
+}
+
+resource "aws_iam_role_policy_attachment" "ecr" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonElasticContainerRegistryPublicPowerUser"
+  role       = aws_iam_role.github_actions.name
+}
+
+resource "aws_iam_role_policy_attachment" "ecr-public" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryPowerUser"
+  role       = aws_iam_role.github_actions.name
+}

--- a/workspaces/workspaces.tf
+++ b/workspaces/workspaces.tf
@@ -50,6 +50,7 @@ locals {
     "github",
     "uptime_robot",
     "broadcast_switcher",
+    "github_actions_assume_aws_role",
   ]
 }
 resource "tfe_workspace" "ws" {


### PR DESCRIPTION
GitHub Actions から 、GitHub OIDC Provider を利用して、指定した AWS IAM Role に AssumeRole するための設定です。

### Concerns

- 指定したリポジトリの GitHub Action のみ AssumeRole を許可するように設定しました。
    - リポジトリが増えるたびにこのファイルの更新が必要になる想定です。
- 既に cloudnativedaysjp/website 用に存在する Role とは別に新規作成するかたちにしました。
- `aws_iam_role_policy_attachment` は既存の `ecr-push` IAM user を元にしました。 ([link](https://us-east-1.console.aws.amazon.com/iam/home?region=us-west-2#/users/details/ecr-push?section=permissions))

### TODOs

- [x] setup Terraform Cloud ([link](https://app.terraform.io/app/cloudnativedaysjp/workspaces/github_actions_assume_aws_role))
    - [x] setup `Version Control`, which is the setting to trigger terraform commands when workspace is updated