### PR TITLE
manage ECR repositories in ap-northeast-1

### DIFF
--- a/ecr/ecr.tf
+++ b/ecr/ecr.tf
@@ -1,27 +1,39 @@
 #
-# Private repositories are created by the following policy.
+# Each private repositories will be pushed the following image tags.
 #
-# * us-west-1:
-#     * pushed tags formatted commit-hash
-#     * following lifecycle policies
-#         * against untagged image, expired 30 days after it was pushed
-#         * against tagged image, no policy
+# * us-west-2:
+#     * pushed tags formatted commit-hash & branch-name
+# * ap-northeast-1:
+#     * pushed tags formatted commit-hash & semver format
 #
 
 locals {
-  repositories = [
-    "dreamkast-ecs",
-    "dreamkast-ui",
-    "dreamkast-weaver",
-    "dreamkast-external-scaler",
-    "emtec-ecu/emtectl",
-    "emtec-ecu/server",
-    "seaman",
-  ]
+  repositories = {
+    "us-west-2" : [
+      "dreamkast-ecs",
+      "dreamkast-ui",
+      "dreamkast-weaver",
+      "dreamkast-external-scaler",
+      "emtec-ecu/emtectl",
+      "emtec-ecu/server",
+      "seaman",
+    ],
+    "ap-northeast-1" : [
+      "dreamkast-ecs",
+      "dreamkast-ui",
+      "dreamkast-weaver",
+      "seaman",
+    ],
+  }
 }
 
+#
+# us-west-2
+#
+
 resource "aws_ecr_repository" "us_west_2" {
-  for_each = toset(local.repositories)
+  provider = aws
+  for_each = toset(local.repositories.us-west-2)
 
   name                 = each.key
   image_tag_mutability = "MUTABLE"
@@ -32,7 +44,8 @@ resource "aws_ecr_repository" "us_west_2" {
 }
 
 resource "aws_ecr_lifecycle_policy" "us_west_2" {
-  for_each = toset(local.repositories)
+  provider = aws
+  for_each = toset(local.repositories.us-west-2)
 
   repository = aws_ecr_repository.us_west_2[each.key].name
   policy     = <<EOF
@@ -70,7 +83,70 @@ resource "aws_ecr_lifecycle_policy" "us_west_2" {
 EOF
 }
 
-resource "aws_ecr_pull_through_cache_rule" "ecr_public" {
+resource "aws_ecr_pull_through_cache_rule" "us_west_2" {
+  provider              = aws
+  ecr_repository_prefix = "ecr-public"
+  upstream_registry_url = "public.ecr.aws"
+}
+
+#
+# asia-northeast-1
+#
+
+resource "aws_ecr_repository" "ap_northeast_1" {
+  provider = aws.ap-northeast-1
+  for_each = toset(local.repositories.ap-northeast-1)
+
+  name                 = each.key
+  image_tag_mutability = "MUTABLE"
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+}
+
+resource "aws_ecr_lifecycle_policy" "ap_northeast_1" {
+  provider = aws.ap-northeast-1
+  for_each = toset(local.repositories.ap-northeast-1)
+
+  repository = aws_ecr_repository.ap_northeast_1[each.key].name
+  policy     = <<EOF
+{
+    "rules": [
+        {
+            "rulePriority": 1,
+            "description": "Expire untagged images older than 3 days",
+            "selection": {
+                "tagStatus": "untagged",
+                "countType": "sinceImagePushed",
+                "countUnit": "days",
+                "countNumber": 3
+            },
+            "action": {
+                "type": "expire"
+            }
+        },
+        {
+            "rulePriority": 2,
+            "description": "Expire images older than 30 days",
+            "selection": {
+                "tagStatus": "tagged",
+                "tagPrefixList": ["commit-"],
+                "countType": "sinceImagePushed",
+                "countUnit": "days",
+                "countNumber": 30
+            },
+            "action": {
+                "type": "expire"
+            }
+        }
+    ]
+}
+EOF
+}
+
+resource "aws_ecr_pull_through_cache_rule" "ap_northeast_1" {
+  provider              = aws.ap-northeast-1
   ecr_repository_prefix = "ecr-public"
   upstream_registry_url = "public.ecr.aws"
 }

--- a/ecr/terraform.tf
+++ b/ecr/terraform.tf
@@ -15,5 +15,11 @@ terraform {
 }
 
 provider "aws" {
+  // default provider
   region = "us-west-2"
+}
+
+provider "aws" {
+  alias  = "ap-northeast-1"
+  region = "ap-northeast-1"
 }


### PR DESCRIPTION
seaman 用の private repository が ap-northeast-1 になかったため、この機会に全ての ap-northeast-1  repository を terraform 化しました。

### Concerns

- us-west-2 の aws_ecr_pull_through_cache_rule の rename により destroy & recreate が走りますが、cache_rule の削除は既存リソースに影響を与えない理解です。
- us-west-2 の以下のリポジトリは現在利用していませんがこの PR では削除していません。別途削除のための PR を作成予定です。
    - dreamkast-external-scaler
    - emtec-ecu/emtectl
    - emtec-ecu/server
    - seaman

### TODOs

- [x] import existence resources
  ```bash
  export AWS_PROFILE=cnd
  export AWS_REGION=ap-northeast-1
  terraform import 'aws_ecr_repository.ap_northeast_1["dreamkast-ecs"]' dreamkast-ecs
  terraform import 'aws_ecr_repository.ap_northeast_1["dreamkast-ui"]' dreamkast-ui
  terraform import 'aws_ecr_repository.ap_northeast_1["dreamkast-weaver"]' dreamkast-weaver
  ```