### PR TITLE
[dev] MediaPackage HarvestJobの失敗をSlackに通知するEventBridgeルールを追加

### DIFF
--- a/dreamkast_infra/dev/eventbridge.tf
+++ b/dreamkast_infra/dev/eventbridge.tf
@@ -1,0 +1,28 @@
+# ------------------------------------------------------------#
+#  EventBridge - MediaPackage HarvestJob Failure Notification
+# ------------------------------------------------------------#
+
+data "aws_sns_topic" "cloudnativedays_alerm" {
+  name = "cloudnativedays-alerm"
+}
+
+resource "aws_cloudwatch_event_rule" "harvestjob_failure" {
+  name        = "${var.prj_prefix}-harvestjob-failure"
+  description = "Detects MediaPackage V2 HarvestJob failures"
+
+  event_pattern = jsonencode({
+    source      = ["aws.mediapackagev2"]
+    detail-type = ["MediaPackageV2 HarvestJob Notification"]
+    detail = {
+      harvestJob = {
+        status = ["FAILED"]
+      }
+    }
+  })
+}
+
+resource "aws_cloudwatch_event_target" "harvestjob_failure_to_sns" {
+  rule      = aws_cloudwatch_event_rule.harvestjob_failure.name
+  target_id = "send-to-sns"
+  arn       = data.aws_sns_topic.cloudnativedays_alerm.arn
+}

--- a/dreamkast_infra/dev/eventbridge.tf
+++ b/dreamkast_infra/dev/eventbridge.tf
@@ -1,16 +1,10 @@
 # ------------------------------------------------------------#
 #  EventBridge - MediaPackage HarvestJob Failure Notification
+#  us-west-2 -> ap-northeast-1 (cross-region) -> SNS -> Slack
 # ------------------------------------------------------------#
 
-data "aws_sns_topic" "cloudnativedays_alerm" {
-  name = "cloudnativedays-alerm"
-}
-
-resource "aws_cloudwatch_event_rule" "harvestjob_failure" {
-  name        = "${var.prj_prefix}-harvestjob-failure"
-  description = "Detects MediaPackage V2 HarvestJob failures"
-
-  event_pattern = jsonencode({
+locals {
+  harvestjob_failure_event_pattern = jsonencode({
     source      = ["aws.mediapackagev2"]
     detail-type = ["MediaPackageV2 HarvestJob Notification"]
     detail = {
@@ -21,8 +15,74 @@ resource "aws_cloudwatch_event_rule" "harvestjob_failure" {
   })
 }
 
-resource "aws_cloudwatch_event_target" "harvestjob_failure_to_sns" {
+# us-west-2: EventBridge rule -> forward to Tokyo event bus
+
+resource "aws_iam_role" "eventbridge_cross_region" {
+  name = "${var.prj_prefix}-eventbridge-cross-region"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect    = "Allow"
+        Principal = { Service = "events.amazonaws.com" }
+        Action    = "sts:AssumeRole"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "eventbridge_cross_region" {
+  name = "put-events-to-tokyo"
+  role = aws_iam_role.eventbridge_cross_region.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = "events:PutEvents"
+        Resource = aws_cloudwatch_event_bus.tokyo.arn
+      }
+    ]
+  })
+}
+
+resource "aws_cloudwatch_event_rule" "harvestjob_failure" {
+  name          = "${var.prj_prefix}-harvestjob-failure"
+  description   = "Detects MediaPackage V2 HarvestJob failures and forwards to Tokyo"
+  event_pattern = local.harvestjob_failure_event_pattern
+}
+
+resource "aws_cloudwatch_event_target" "harvestjob_failure_to_tokyo" {
   rule      = aws_cloudwatch_event_rule.harvestjob_failure.name
-  target_id = "send-to-sns"
-  arn       = data.aws_sns_topic.cloudnativedays_alerm.arn
+  target_id = "forward-to-tokyo"
+  arn       = aws_cloudwatch_event_bus.tokyo.arn
+  role_arn  = aws_iam_role.eventbridge_cross_region.arn
+}
+
+# ap-northeast-1: EventBridge rule -> SNS
+
+resource "aws_cloudwatch_event_bus" "tokyo" {
+  provider = aws.tokyo
+  name     = "${var.prj_prefix}-harvestjob"
+}
+
+data "aws_sns_topic" "cloudnativedays_alerm" {
+  provider = aws.tokyo
+  name     = "cloudnativedays-alerm"
+}
+
+resource "aws_cloudwatch_event_rule" "harvestjob_failure_tokyo" {
+  provider       = aws.tokyo
+  name           = "${var.prj_prefix}-harvestjob-failure"
+  description    = "Forwards MediaPackage HarvestJob failures to SNS"
+  event_bus_name = aws_cloudwatch_event_bus.tokyo.name
+  event_pattern  = local.harvestjob_failure_event_pattern
+}
+
+resource "aws_cloudwatch_event_target" "harvestjob_failure_to_sns" {
+  provider       = aws.tokyo
+  rule           = aws_cloudwatch_event_rule.harvestjob_failure_tokyo.name
+  event_bus_name = aws_cloudwatch_event_bus.tokyo.name
+  target_id      = "send-to-sns"
+  arn            = data.aws_sns_topic.cloudnativedays_alerm.arn
 }

--- a/dreamkast_infra/dev/terraform.tf
+++ b/dreamkast_infra/dev/terraform.tf
@@ -17,3 +17,8 @@ terraform {
 provider "aws" {
   region = "us-west-2"
 }
+
+provider "aws" {
+  alias  = "tokyo"
+  region = "ap-northeast-1"
+}


### PR DESCRIPTION
- MediaPackage V2 の HarvestJob 失敗時に Slack へ通知する仕組みを追加
- us-west-2（dev） で発生した EventBridge イベントを、クロスリージョン転送で東京のカスタム EventBus に送信
- 東京側で既存の cloudnativedays-alerm SNS トピックに流し、AWS Chatbot 経由で Slack に通知
- 東京リージョン用の provider alias を追加