### PR TITLE
[prod] MediaPackage HarvestJobの失敗をSlackに通知するEventBridgeルールを追加

### DIFF
--- a/dreamkast_infra/prod/eventbridge.tf
+++ b/dreamkast_infra/prod/eventbridge.tf
@@ -1,0 +1,28 @@
+# ------------------------------------------------------------#
+#  EventBridge - MediaPackage HarvestJob Failure Notification
+# ------------------------------------------------------------#
+
+data "aws_sns_topic" "cloudnativedays_alerm" {
+  name = "cloudnativedays-alerm"
+}
+
+resource "aws_cloudwatch_event_rule" "harvestjob_failure" {
+  name        = "${var.prj_prefix}-harvestjob-failure"
+  description = "Detects MediaPackage V2 HarvestJob failures"
+
+  event_pattern = jsonencode({
+    source      = ["aws.mediapackagev2"]
+    detail-type = ["MediaPackageV2 HarvestJob Notification"]
+    detail = {
+      harvestJob = {
+        status = ["FAILED"]
+      }
+    }
+  })
+}
+
+resource "aws_cloudwatch_event_target" "harvestjob_failure_to_sns" {
+  rule      = aws_cloudwatch_event_rule.harvestjob_failure.name
+  target_id = "send-to-sns"
+  arn       = data.aws_sns_topic.cloudnativedays_alerm.arn
+}


### PR DESCRIPTION
- prod 環境に MediaPackage V2 HarvestJob 失敗時の Slack 通知を追加
- EventBridge ルールで FAILED イベントをキャッチし、既存の cloudnativedays-alerm SNS トピックに送信
- prod は全て東京リージョンのためクロスリージョン転送は不要

dev: https://github.com/cloudnativedaysjp/terraform/pull/262