### PR TITLE
[DEV&STG&PROD] sGTMに対応するECRリポジトリを追加

### DIFF
--- a/ecr/ecr.tf
+++ b/ecr/ecr.tf
@@ -14,7 +14,7 @@ locals {
       "dreamkast-otelcol",
       "dreamkast-ui",
       "dreamkast-weaver",
-      "dreamkast-sgtm"
+      "dreamkast-sgtm",
     ],
     "ap-northeast-1" : [
       "dreamkast-ecs",
@@ -22,7 +22,7 @@ locals {
       "dreamkast-ui",
       "dreamkast-weaver",
       "seaman",
-      "dreamkast-sgtm"
+      "dreamkast-sgtm",
     ],
   }
 }

--- a/ecr/ecr.tf
+++ b/ecr/ecr.tf
@@ -14,6 +14,7 @@ locals {
       "dreamkast-otelcol",
       "dreamkast-ui",
       "dreamkast-weaver",
+      "dreamkast-sgtm"
     ],
     "ap-northeast-1" : [
       "dreamkast-ecs",
@@ -21,6 +22,7 @@ locals {
       "dreamkast-ui",
       "dreamkast-weaver",
       "seaman",
+      "dreamkast-sgtm"
     ],
   }
 }


### PR DESCRIPTION
## 概要

- sGTMのイメージをpushするためのECRレポジトリを追加　

## この後の動き
- sGTMの公式イメージ(https://console.cloud.google.com/artifacts/docker/cloud-tagging-10302018/us/gcr.io/gtm-cloud-image) をpullしてpushさせていただきます。
- ECSサービス定義以外のインフラに対して変更を行うPRを発行させていただきます。