### PR TITLE
[PROD]: sGTM用のSG, IAM role, IAM policyの追加&ALBの設定変更

### DIFF
--- a/dreamkast_infra/prod/alb_targets.tf
+++ b/dreamkast_infra/prod/alb_targets.tf
@@ -127,3 +127,46 @@ resource "aws_lb_target_group" "dreamkast_weaver" {
     matcher             = 200
   }
 }
+
+# ------------------------------------------------------------#
+# for sGTM
+# ------------------------------------------------------------#
+resource "aws_lb_listener_rule" "dreamkast_sgtm" {
+  listener_arn = aws_lb_listener.alb.arn
+  priority     = 10
+  action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.dreamkast_sgtm.arn
+  }
+  condition {
+    host_header {
+      values = ["sgtm.cloudnativedays.jp"]
+    }
+  }
+  condition {
+    path_pattern {
+      values = ["/*"]
+    }
+  }
+}
+
+resource "aws_lb_target_group" "dreamkast_sgtm" {
+  name        = "dreamkast-production-sgtm"
+  port        = 8080
+  protocol    = "HTTP"
+  vpc_id      = aws_vpc.this.id
+  target_type = "ip"
+
+  deregistration_delay = 60
+
+  health_check {
+    protocol            = "HTTP"
+    path                = "/healthz"
+    port                = 8080
+    healthy_threshold   = 3
+    unhealthy_threshold = 2
+    timeout             = 5
+    interval            = 30
+    matcher             = 200
+  }
+}

--- a/dreamkast_infra/prod/ecs.tf
+++ b/dreamkast_infra/prod/ecs.tf
@@ -618,6 +618,51 @@ resource "aws_security_group" "ecs-harvestjob" {
 }
 
 # ------------------------------------------------------------#
+# for sGTM
+# ------------------------------------------------------------#
+resource "aws_iam_role" "ecs-sgtm" {
+  name = "${var.prj_prefix}-ecs-sgtm"
+
+  assume_role_policy = data.aws_iam_policy_document.assume_role_policy_ecs.json
+
+  #tags = {
+  #  Environment = "${var.prj_prefix}"
+  #}
+}
+
+resource "aws_iam_role_policy_attachment" "ecs-sgtm-ssm" {
+  role       = aws_iam_role.ecs-sgtm.name
+  policy_arn = data.aws_iam_policy.AmazonSSMManagedInstanceCore.arn
+}
+
+resource "aws_security_group" "ecs-sgtm" {
+  name   = "${var.prj_prefix}-ecs-sgtm"
+  vpc_id = aws_vpc.this.id
+
+  ingress {
+    description = "tcp/8080"
+    protocol    = "tcp"
+    from_port   = 8080
+    to_port     = 8080
+    security_groups = [
+      aws_security_group.alb.id,
+    ]
+  }
+
+  egress {
+    description = "allow all"
+    protocol    = "-1"
+    from_port   = 0
+    to_port     = 0
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  #tags = {
+  #  Environment = "${var.prj_prefix}"
+  #}
+}
+
+# ------------------------------------------------------------#
 # for medialive-alert
 # ------------------------------------------------------------#
 resource "aws_iam_role" "ecs-medialive-alert" {


### PR DESCRIPTION
## 概要
- [devの設定](https://github.com/cloudnativedaysjp/terraform/pull/266)を参考に、STG環境へsGTM用のALBターゲットグループ、リスナールールの追加


## 特にチェックして欲しいこと
- ネットワーク的な変更が入ります。特に優先度とドメインについて確認をお願いします。

## この後やること
- dreamkast-infra側でecspressoのECSサービス定義を追加
- `sgtm.cloudnativedays.jp`の追加