### PR TITLE
fix: change default status code from 503 to 404 in ALB listener

### DIFF
--- a/dreamkast_infra/dev/alb.tf
+++ b/dreamkast_infra/dev/alb.tf
@@ -52,8 +52,8 @@ resource "aws_lb_listener" "alb" {
 
     fixed_response {
       content_type = "text/plain"
-      status_code  = "503"
-      message_body = "no appropriately backends"
+      status_code  = "404"
+      message_body = "Not Found"
     }
   }
 


### PR DESCRIPTION
## Summary

  - ALB のデフォルトアクション(ホストヘッダーが一致しないリクエスト)のレスポンスコードを 503 から 404 に変更
  - ボットやスキャナー等の不正なホストヘッダーによるアクセスがバックエンド障害の 5xxアラートと混同されるのを防止する

##  Background

  現状、ALB のリスナールールにマッチしないリクエストに対して 503
  を返却しているが、これはバックエンドの障害時に返却される 503 と区別がつかず、不要なアラートの原因となる。ホストヘ
  ッダーが一致しないリクエストは「存在しないリソースへのアクセス」であるため、404 が適切。

##  Scope

  - dev 環境のみ