### PR TITLE
feat: add S3 bucket for ALB access logs (production env)

### DIFF
--- a/dreamkast_infra/prod/alb.tf
+++ b/dreamkast_infra/prod/alb.tf
@@ -10,6 +10,15 @@ resource "aws_lb" "alb" {
 
   enable_deletion_protection = true
 
+  access_logs {
+    bucket  = aws_s3_bucket.alb_log.id
+    enabled = true
+  }
+
+  depends_on = [
+    aws_s3_bucket_policy.alb_log,
+  ]
+
   #tags = {
   #  Environment = "${var.prj_prefix}"
   #}

--- a/dreamkast_infra/prod/alb.tf
+++ b/dreamkast_infra/prod/alb.tf
@@ -12,6 +12,7 @@ resource "aws_lb" "alb" {
 
   access_logs {
     bucket  = aws_s3_bucket.alb_log.id
+    prefix  = "alb"
     enabled = true
   }
 

--- a/dreamkast_infra/prod/athena.tf
+++ b/dreamkast_infra/prod/athena.tf
@@ -1,0 +1,199 @@
+# ------------------------------------------------------------#
+# Athena workgroup for ALB log analysis
+# ------------------------------------------------------------#
+resource "aws_athena_workgroup" "alb_log" {
+  name = "${var.prj_prefix}-alb-log"
+
+  configuration {
+    result_configuration {
+      output_location = "s3://${aws_s3_bucket.athena_query_results.id}/"
+
+      encryption_configuration {
+        encryption_option = "SSE_S3"
+      }
+    }
+  }
+}
+
+# ------------------------------------------------------------#
+# Glue catalog database and table for ALB access logs
+# https://docs.aws.amazon.com/athena/latest/ug/application-load-balancer-logs.html
+# ------------------------------------------------------------#
+resource "aws_glue_catalog_database" "alb_log" {
+  name = replace("${var.prj_prefix}_alb_log", "-", "_")
+}
+
+resource "aws_glue_catalog_table" "alb_log" {
+  name          = "alb_access_logs"
+  database_name = aws_glue_catalog_database.alb_log.name
+
+  table_type = "EXTERNAL_TABLE"
+
+  parameters = {
+    EXTERNAL                       = "TRUE"
+    "projection.enabled"           = "true"
+    "projection.day.type"          = "date"
+    "projection.day.range"         = "2026/01/01,NOW"
+    "projection.day.format"        = "yyyy/MM/dd"
+    "projection.day.interval"      = "1"
+    "projection.day.interval.unit" = "DAYS"
+    "storage.location.template"    = "s3://${aws_s3_bucket.alb_log.id}/alb/AWSLogs/${var.aws_account_id}/elasticloadbalancing/ap-northeast-1/$${day}"
+  }
+
+  partition_keys {
+    name = "day"
+    type = "string"
+  }
+
+  storage_descriptor {
+    location      = "s3://${aws_s3_bucket.alb_log.id}/alb/AWSLogs/${var.aws_account_id}/elasticloadbalancing/ap-northeast-1/"
+    input_format  = "org.apache.hadoop.mapred.TextInputFormat"
+    output_format = "org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat"
+
+    ser_de_info {
+      serialization_library = "org.apache.hadoop.hive.serde2.RegexSerDe"
+
+      parameters = {
+        "serialization.format" = "1"
+        "input.regex"          = "([^ ]*) ([^ ]*) ([^ ]*) ([^ ]*):([0-9]*) ([^ ]*)[:-]([0-9]*) ([-.0-9]*) ([-.0-9]*) ([-.0-9]*) (|[-0-9]*) (-|[-0-9]*) ([-0-9]*) ([-0-9]*) \"([^ ]*) (.*) (- |[^ ]*)\" \"([^\"]*)\" ([A-Z0-9-_]+) ([A-Za-z0-9.-]*) ([^ ]*) \"([^\"]*)\" \"([^\"]*)\" \"([^\"]*)\" ([-.0-9]*) ([^ ]*) \"([^\"]*)\" \"([^\"]*)\" \"([^ ]*)\" \"([^\\s]+?)\" \"([^\\s]+)\" \"([^ ]*)\" \"([^ ]*)\" ?([^ ]*)?"
+      }
+    }
+
+    columns {
+      name = "type"
+      type = "string"
+    }
+    columns {
+      name = "time"
+      type = "string"
+    }
+    columns {
+      name = "elb"
+      type = "string"
+    }
+    columns {
+      name = "client_ip"
+      type = "string"
+    }
+    columns {
+      name = "client_port"
+      type = "int"
+    }
+    columns {
+      name = "target_ip"
+      type = "string"
+    }
+    columns {
+      name = "target_port"
+      type = "int"
+    }
+    columns {
+      name = "request_processing_time"
+      type = "double"
+    }
+    columns {
+      name = "target_processing_time"
+      type = "double"
+    }
+    columns {
+      name = "response_processing_time"
+      type = "double"
+    }
+    columns {
+      name = "elb_status_code"
+      type = "int"
+    }
+    columns {
+      name = "target_status_code"
+      type = "string"
+    }
+    columns {
+      name = "received_bytes"
+      type = "bigint"
+    }
+    columns {
+      name = "sent_bytes"
+      type = "bigint"
+    }
+    columns {
+      name = "request_verb"
+      type = "string"
+    }
+    columns {
+      name = "request_url"
+      type = "string"
+    }
+    columns {
+      name = "request_proto"
+      type = "string"
+    }
+    columns {
+      name = "user_agent"
+      type = "string"
+    }
+    columns {
+      name = "ssl_cipher"
+      type = "string"
+    }
+    columns {
+      name = "ssl_protocol"
+      type = "string"
+    }
+    columns {
+      name = "target_group_arn"
+      type = "string"
+    }
+    columns {
+      name = "trace_id"
+      type = "string"
+    }
+    columns {
+      name = "domain_name"
+      type = "string"
+    }
+    columns {
+      name = "chosen_cert_arn"
+      type = "string"
+    }
+    columns {
+      name = "matched_rule_priority"
+      type = "string"
+    }
+    columns {
+      name = "request_creation_time"
+      type = "string"
+    }
+    columns {
+      name = "actions_executed"
+      type = "string"
+    }
+    columns {
+      name = "redirect_url"
+      type = "string"
+    }
+    columns {
+      name = "lambda_error_reason"
+      type = "string"
+    }
+    columns {
+      name = "target_port_list"
+      type = "string"
+    }
+    columns {
+      name = "target_status_code_list"
+      type = "string"
+    }
+    columns {
+      name = "classification"
+      type = "string"
+    }
+    columns {
+      name = "classification_reason"
+      type = "string"
+    }
+    columns {
+      name = "conn_trace_id"
+      type = "string"
+    }
+  }
+}

--- a/dreamkast_infra/prod/s3.tf
+++ b/dreamkast_infra/prod/s3.tf
@@ -98,3 +98,48 @@ resource "aws_s3_bucket_policy" "alb_log" {
   bucket = aws_s3_bucket.alb_log.id
   policy = data.aws_iam_policy_document.alb_log.json
 }
+
+# ------------------------------------------------------------#
+# S3 Bucket for Athena query results
+# ------------------------------------------------------------#
+resource "aws_s3_bucket" "athena_query_results" {
+  bucket = "${var.prj_prefix}-athena-query-results"
+
+  tags = {
+    Name = "${var.prj_prefix}-athena-query-results"
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "athena_query_results" {
+  bucket = aws_s3_bucket.athena_query_results.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "athena_query_results" {
+  bucket = aws_s3_bucket.athena_query_results.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "athena_query_results" {
+  bucket = aws_s3_bucket.athena_query_results.id
+
+  rule {
+    id     = "delete_old_query_results"
+    status = "Enabled"
+
+    filter {}
+
+    expiration {
+      days = 30
+    }
+  }
+}

--- a/dreamkast_infra/prod/s3.tf
+++ b/dreamkast_infra/prod/s3.tf
@@ -55,6 +55,16 @@ resource "aws_s3_bucket_public_access_block" "alb_log" {
   restrict_public_buckets = true
 }
 
+resource "aws_s3_bucket_server_side_encryption_configuration" "alb_log" {
+  bucket = aws_s3_bucket.alb_log.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
 resource "aws_s3_bucket_lifecycle_configuration" "alb_log" {
   bucket = aws_s3_bucket.alb_log.id
 
@@ -80,7 +90,7 @@ data "aws_iam_policy_document" "alb_log" {
       identifiers = [data.aws_elb_service_account.main.arn]
     }
     actions   = ["s3:PutObject"]
-    resources = ["${aws_s3_bucket.alb_log.arn}/AWSLogs/${var.aws_account_id}/*"]
+    resources = ["${aws_s3_bucket.alb_log.arn}/alb/AWSLogs/${var.aws_account_id}/*"]
   }
 }
 

--- a/dreamkast_infra/prod/s3.tf
+++ b/dreamkast_infra/prod/s3.tf
@@ -34,3 +34,57 @@ resource "aws_s3_bucket_lifecycle_configuration" "bucket_lifecycle" {
     }
   }
 }
+
+# ------------------------------------------------------------#
+# S3 Bucket for ALB access logs
+# ------------------------------------------------------------#
+resource "aws_s3_bucket" "alb_log" {
+  bucket = "${var.prj_prefix}-alb-log"
+
+  tags = {
+    Name = "${var.prj_prefix}-alb-log"
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "alb_log" {
+  bucket = aws_s3_bucket.alb_log.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "alb_log" {
+  bucket = aws_s3_bucket.alb_log.id
+
+  rule {
+    id     = "delete_old_logs"
+    status = "Enabled"
+
+    filter {}
+
+    expiration {
+      days = 30
+    }
+  }
+}
+
+data "aws_elb_service_account" "main" {}
+
+data "aws_iam_policy_document" "alb_log" {
+  statement {
+    effect = "Allow"
+    principals {
+      type        = "AWS"
+      identifiers = [data.aws_elb_service_account.main.arn]
+    }
+    actions   = ["s3:PutObject"]
+    resources = ["${aws_s3_bucket.alb_log.arn}/AWSLogs/${var.aws_account_id}/*"]
+  }
+}
+
+resource "aws_s3_bucket_policy" "alb_log" {
+  bucket = aws_s3_bucket.alb_log.id
+  policy = data.aws_iam_policy_document.alb_log.json
+}


### PR DESCRIPTION
## Summary
- prod環境のALBアクセスログ保存用S3バケット (`dreamkast-prod-alb-log`) を追加
- 30日後に自動削除するライフサイクルルールを設定
- `aws_lb.alb` に `access_logs` ブロックを追加してログ出力を有効化（瞬断なし、ModifyLoadBalancerAttributes API）

## Test plan
- [ ] `terraform plan` で意図したリソース（S3バケット、public access block、ライフサイクル、バケットポリシー、ALBのaccess_logs設定）が作成されることを確認
- [ ] apply後、ALBのアクセスログがS3バケットに書き込まれることを確認