### PR TITLE
feat(stg/rds): MySQL 8.0.42 から 8.4.9 へアップグレード

### DIFF
--- a/dreamkast_infra/stg/rds.tf
+++ b/dreamkast_infra/stg/rds.tf
@@ -7,6 +7,14 @@ resource "aws_db_parameter_group" "rds_parameter_group" {
   description = "${var.prj_prefix}-${var.db_instance_name}-parm"
 
   # データベースに設定するパラメーター
+  # MySQL 8.4 では mysql_native_password がデフォルト無効(OFF)。
+  # 既存ユーザ(マスターユーザ含む)は native_password で作成されているため、
+  # アップグレード後も認証できるよう ON で維持する。静的パラメータのため再起動で反映。
+  parameter {
+    name         = "mysql_native_password"
+    value        = "1"
+    apply_method = "pending-reboot"
+  }
   parameter {
     name  = "slow_query_log"
     value = 1
@@ -94,12 +102,13 @@ resource "aws_db_instance" "rds_instance" {
 
   parameter_group_name = aws_db_parameter_group.rds_parameter_group.name
 
-  backup_window              = "18:00-18:30"
-  maintenance_window         = "Sat:19:00-Sat:19:30"
-  backup_retention_period    = 7
-  auto_minor_version_upgrade = false
-  copy_tags_to_snapshot      = true
-  skip_final_snapshot        = true
+  backup_window               = "18:00-18:30"
+  maintenance_window          = "Sat:19:00-Sat:19:30"
+  backup_retention_period     = 7
+  auto_minor_version_upgrade  = false
+  allow_major_version_upgrade = true
+  copy_tags_to_snapshot       = true
+  skip_final_snapshot         = true
 
   tags = {
     Name = "${var.db_instance_name}"

--- a/dreamkast_infra/stg/rds.tf
+++ b/dreamkast_infra/stg/rds.tf
@@ -7,14 +7,6 @@ resource "aws_db_parameter_group" "rds_parameter_group" {
   description = "${var.prj_prefix}-${var.db_instance_name}-parm"
 
   # データベースに設定するパラメーター
-  # MySQL 8.4 では mysql_native_password がデフォルト無効(OFF)。
-  # 既存ユーザ(マスターユーザ含む)は native_password で作成されているため、
-  # アップグレード後も認証できるよう ON で維持する。静的パラメータのため再起動で反映。
-  parameter {
-    name         = "mysql_native_password"
-    value        = "1"
-    apply_method = "pending-reboot"
-  }
   parameter {
     name  = "slow_query_log"
     value = 1

--- a/dreamkast_infra/stg/variables.tf
+++ b/dreamkast_infra/stg/variables.tf
@@ -14,11 +14,11 @@ variable "prj_prefix" {
 #  RDS
 # ------------------------------------------------------------#
 variable "mysql_major_version" {
-  default = "8.0"
+  default = "8.4"
 }
 
 variable "mysql_minor_version" {
-  default = "42"
+  default = "9"
 }
 
 variable "db_instance_name" {


### PR DESCRIPTION
## 概要
RDS for MySQL 8.0 は **2026-07-31 に標準サポート終了**（以降は有償の Extended Support に自動移行）となるため、LTS の **MySQL 8.4.9** へ in-place でメジャーアップグレードする。本 PR では **staging を先行**で対応する（prod は検証後に別 PR #277）。

8.0.42 → 8.4.9 は中間バージョン不要で直接アップグレード可能。

## 変更内容（`dreamkast_infra/stg/` のみ）
- `variables.tf`: `mysql_major_version` `8.0`→`8.4`、`mysql_minor_version` `42`→`9`
  - → `engine_version` が `8.4.9`、パラメータグループ `family` が `mysql8.4` に連動
- `rds.tf`: DB インスタンスに `allow_major_version_upgrade = true` を追加

## 認証プラグインの方針
**8.4 のデフォルト（`mysql_native_password` = OFF / `caching_sha2_password`）に従う。**
`mysql_native_password` を強制有効化するパラメータは設定しない。

⚠️ **アップグレード前の必須作業（Terraform 外）**: 現在の既存ユーザ（マスター含む）は `mysql_native_password` で作成されているため、そのまま上げると認証不可になる。事前に `caching_sha2_password` へ移行すること。
```sql
SELECT user, host, plugin FROM mysql.user;  -- native のユーザを洗い出し
ALTER USER 'admin'@'%' IDENTIFIED WITH caching_sha2_password BY 'パスワード';
-- アプリ用ユーザなど他の native ユーザも同様に移行
```
※ アプリ側 PR cloudnativedaysjp/dreamkast#2843 は **`caching_sha2_password` + TLS 強制に対応済み**。`mysql_native_password` 維持はしない方針に統一済みで、mysql2 0.5.6 での TLS 接続も検証済み（本番は `verify_identity` + RDS CA バンドルで検証）。

## apply 前の確認（plan で要チェック）
- `aws_db_instance.rds_instance` が engine_version `8.0.42 → 8.4.9` の **更新**（破棄/再作成ではない）
- family 変更で既存パラメータ（`slow_query_log` / `long_query_time` / `log_output`）に予期せぬ差分がないか

## apply 後の確認 SQL
```sql
SELECT VERSION();                          -- 8.4.9
SELECT user, host, plugin FROM mysql.user; -- caching_sha2_password になっていること
```
その後アプリの DB 接続（TLS）・主要機能を検証する。

## 補足
- prod は staging 検証完了後に対応予定（#277）
- アプリ側 PR: cloudnativedaysjp/dreamkast#2843

🤖 Generated with [Claude Code](https://claude.com/claude-code)