### PR TITLE
fix(stg/rds): MySQL 8.4 用パラメータグループを新規作成してアタッチ

### DIFF
--- a/dreamkast_infra/stg/rds.tf
+++ b/dreamkast_infra/stg/rds.tf
@@ -1,8 +1,33 @@
 # ------------------------------------------------------------#
 #  RDS parameter group
 # ------------------------------------------------------------#
+# 旧 MySQL 8.0 用パラメータグループ。
+# family は変更不可属性なので 8.4 用は別リソースで新規作成し、こちらは削除せず残す
+# (インスタンスがまだメンバーのうちに削除すると InvalidDBParameterGroupState で失敗するため)。
+# インスタンスを 8.4 用グループへ付け替えた後、別 PR でこのリソースを削除する。
 resource "aws_db_parameter_group" "rds_parameter_group" {
   name        = "${var.prj_prefix}-${var.db_instance_name}-parametergroup"
+  family      = "mysql8.0"
+  description = "${var.prj_prefix}-${var.db_instance_name}-parm"
+
+  # データベースに設定するパラメーター
+  parameter {
+    name  = "slow_query_log"
+    value = 1
+  }
+  parameter {
+    name  = "long_query_time"
+    value = var.long_query_time
+  }
+  parameter {
+    name  = "log_output"
+    value = "FILE"
+  }
+}
+
+# MySQL 8.4 用パラメータグループ(新規)。インスタンスはこちらをアタッチする。
+resource "aws_db_parameter_group" "rds_parameter_group_84" {
+  name        = "${var.prj_prefix}-${var.db_instance_name}-parametergroup-mysql${replace(var.mysql_major_version, ".", "")}"
   family      = "mysql${var.mysql_major_version}"
   description = "${var.prj_prefix}-${var.db_instance_name}-parm"
 
@@ -92,7 +117,7 @@ resource "aws_db_instance" "rds_instance" {
   publicly_accessible    = false
   multi_az               = var.multi_az
 
-  parameter_group_name = aws_db_parameter_group.rds_parameter_group.name
+  parameter_group_name = aws_db_parameter_group.rds_parameter_group_84.name
 
   backup_window               = "18:00-18:30"
   maintenance_window          = "Sat:19:00-Sat:19:30"


### PR DESCRIPTION
## 背景 / 問題

MySQL 8.0 → 8.4 アップグレードの apply で以下のエラーが発生した。

```
Error: deleting RDS DB Parameter Group (dreamkast-stg-rds-parametergroup):
InvalidDBParameterGroupState: One or more database instances are still members of
this parameter group dreamkast-stg-rds-parametergroup, so the group cannot be deleted
```

`aws_db_parameter_group` の `family` は変更不可(ForceNew)属性のため、`family` を
`mysql8.0` → `mysql8.4` に変えると Terraform はパラメータグループを置き換えようとする。
`name` が同名固定なので「旧グループ削除 → 同名で作成」の順になり、削除時点で DB インスタンスが
まだ旧グループのメンバーであるため削除に失敗していた。

## 対応

destroy を伴わない2段階(別 PR)方式に変更する。

**本 PR**
- 旧 8.0 用 `rds_parameter_group` は削除せず残す(`family` を `mysql8.0` に固定し既存状態と一致させ差分を出さない)
- 8.4 用 `rds_parameter_group_84`(`dreamkast-stg-rds-parametergroup-mysql84`)を新規作成
- インスタンスの `parameter_group_name` を 8.4 用グループへ変更

**次 PR**
- インスタンスが 8.4 用グループへ付け替わったことを確認後、旧 `rds_parameter_group` リソースを削除(この時点でメンバーが居ないため削除成功)

## apply の想定挙動

1. 8.4 用パラメータグループを新規作成
2. インスタンスをメジャーアップグレード(8.4.9)＋新グループへ付け替え
3. 旧グループは no-change(destroy されない)

## 確認事項

- [ ] `terraform plan` で「8.4 PG 新規作成 / インスタンス modify / 旧 PG は no-change」であることを確認
- [ ] 前回 apply が途中失敗しているため現在の実 state を plan で確認してから apply

🤖 Generated with [Claude Code](https://claude.com/claude-code)