### PR TITLE
feat(prod/rds): MySQL 8.0.42 から 8.4.9 へアップグレード

### DIFF
--- a/dreamkast_infra/prod/rds.tf
+++ b/dreamkast_infra/prod/rds.tf
@@ -1,6 +1,6 @@
 locals {
-  mysql_major_version      = "8.0"
-  mysql_minor_version      = "42"
+  mysql_major_version      = "8.4"
+  mysql_minor_version      = "9"
   db_instance_name         = "rds"
   db_instance_class        = "db.t4g.small"
   db_instance_storage_size = 30
@@ -14,8 +14,33 @@ locals {
 # ------------------------------------------------------------#
 #  RDS parameter group
 # ------------------------------------------------------------#
+# 旧 MySQL 8.0 用パラメータグループ。
+# family は変更不可属性なので 8.4 用は別リソースで新規作成し、こちらは削除せず残す
+# (インスタンスがまだメンバーのうちに削除すると InvalidDBParameterGroupState で失敗するため)。
+# インスタンスを 8.4 用グループへ付け替えた後、別 PR でこのリソースを削除する。
 resource "aws_db_parameter_group" "rds_parameter_group" {
   name        = "${var.prj_prefix}-${local.db_instance_name}-parametergroup"
+  family      = "mysql8.0"
+  description = "${var.prj_prefix}-${local.db_instance_name}-parm"
+
+  # データベースに設定するパラメーター
+  parameter {
+    name  = "slow_query_log"
+    value = 1
+  }
+  parameter {
+    name  = "long_query_time"
+    value = local.long_query_time
+  }
+  parameter {
+    name  = "log_output"
+    value = "FILE"
+  }
+}
+
+# MySQL 8.4 用パラメータグループ(新規)。インスタンスはこちらをアタッチする。
+resource "aws_db_parameter_group" "rds_parameter_group_84" {
+  name        = "${var.prj_prefix}-${local.db_instance_name}-parametergroup-mysql${replace(local.mysql_major_version, ".", "")}"
   family      = "mysql${local.mysql_major_version}"
   description = "${var.prj_prefix}-${local.db_instance_name}-parm"
 
@@ -104,14 +129,15 @@ resource "aws_db_instance" "rds_instance" {
   publicly_accessible    = false
   multi_az               = local.rds_multi_az
 
-  parameter_group_name = aws_db_parameter_group.rds_parameter_group.name
+  parameter_group_name = aws_db_parameter_group.rds_parameter_group_84.name
 
-  backup_window              = "18:00-18:30"
-  maintenance_window         = "Sat:19:00-Sat:19:30"
-  backup_retention_period    = 7
-  auto_minor_version_upgrade = false
-  copy_tags_to_snapshot      = true
-  skip_final_snapshot        = true
+  backup_window               = "18:00-18:30"
+  maintenance_window          = "Sat:19:00-Sat:19:30"
+  backup_retention_period     = 7
+  auto_minor_version_upgrade  = false
+  allow_major_version_upgrade = true
+  copy_tags_to_snapshot       = true
+  skip_final_snapshot         = true
 
   tags = { Name = "${local.db_instance_name}" }
 }


### PR DESCRIPTION
## 概要

RDS for MySQL 8.0 は 2026-07-31 に標準サポート終了となるため、LTS の 8.4.9 へ in-place で
メジャーアップグレードする（staging に続き production）。

stg (#278 / #279) と同じく、パラメータグループは destroy を伴わない2段階(別 PR)方式で移行する。

## 変更内容（本 PR = 前段）

- `mysql_major_version` 8.0 → 8.4 / `mysql_minor_version` 42 → 9（engine_version 8.4.9）
- `allow_major_version_upgrade = true` を追加
- 旧 8.0 用 `rds_parameter_group` は削除せず残す（`family` を `mysql8.0` に固定し差分を出さない）
- 8.4 用 `rds_parameter_group_84`（`dreamkast-prod-rds-parametergroup-mysql84`）を新規作成しインスタンスへアタッチ

## apply の想定挙動

1. 8.4 用パラメータグループを新規作成
2. インスタンスをメジャーアップグレード(8.4.9)＋新グループへ付け替え
3. 旧グループは no-change（destroy されない）

## 後段 PR

- インスタンス付け替え完了後、旧 `rds_parameter_group`(mysql8.0) を削除する PR を別途用意（#280 相当）

## 確認事項

- [ ] **本番 DB のメジャーバージョンアップ**。メンテナンスウィンドウ/ダウンタイムを調整の上 apply すること
- [ ] apply 前にバックアップ/スナップショットを確認
- [ ] `terraform plan` で「8.4 PG 新規作成 / インスタンス modify / 旧 PG は no-change」を確認
- [ ] MySQL 8.4 では mysql_native_password がデフォルト無効。既存ユーザの認証方式に問題が無いか事前確認（stg の検証結果を参照）

🤖 Generated with [Claude Code](https://claude.com/claude-code)