### PR TITLE
prod の ElastiCache Redis を ingress 全削除で到達不能にする

### DIFF
--- a/dreamkast_infra/prod/redis.tf
+++ b/dreamkast_infra/prod/redis.tf
@@ -26,24 +26,15 @@ module "elasticache-redis" {
   subnets          = aws_subnet.intra[*].id
   port             = 6379
   allow_all_egress = true
-  additional_security_group_rules = [
-    {
-      type        = "ingress"
-      description = "Redis from private subnet"
-      from_port   = 6379
-      to_port     = 6379
-      protocol    = "tcp"
-      cidr_blocks = aws_subnet.private[*].cidr_block
-    },
-    {
-      type        = "ingress"
-      description = "Redis from public subnet"
-      from_port   = 6379
-      to_port     = 6379
-      protocol    = "tcp"
-      cidr_blocks = aws_subnet.public[*].cidr_block
-    }
-  ]
+
+  # 脱Redis (dreamkast#2844 / v4.20.0) により prod のアプリは Redis を参照しなくなった。
+  # ElastiCache には RDS のような stop/start が無いため、削除前の最終確認として
+  # ingress を全て外し、クラスタを残したまま到達不能にする。
+  #
+  # 一定期間問題が無いことを確認できたら、この module ごと削除する。
+  # 切り戻す場合はこの commit を revert すれば元の ingress が復活する
+  # (private / public サブネットの CIDR から 6379/tcp を許可)。
+  additional_security_group_rules = []
 
   replication_group_id     = "${var.prj_prefix}-redis"
   maintenance_window       = "sun:22:00-sun:23:30"


### PR DESCRIPTION
## 概要

脱Redis（[dreamkast#2844](https://github.com/cloudnativedaysjp/dreamkast/pull/2844)）を `v4.20.0` として prod にリリースし、アプリが Redis を参照しなくなりました。削除前の最終確認として、**ElastiCache のクラスタは残したまま接続だけを遮断**します。

```diff
   allow_all_egress = true
-  additional_security_group_rules = [
-    {
-      type        = "ingress"
-      description = "Redis from private subnet"
-      ...
-    },
-    {
-      type        = "ingress"
-      description = "Redis from public subnet"
-      ...
-    }
-  ]
+  additional_security_group_rules = []
```

## なぜ delete ではなく ingress 遮断か

ElastiCache には RDS のような **stop/start がありません**。一方でいきなり `delete-replication-group` すると、スナップショットから復元してもエンドポイントが変わるため厳密な切り戻しになりません。

ingress を外す方法なら、クラスタ・エンドポイント・データがそのまま残り、**この PR を revert して apply するだけで即座に復旧**できます。

## 遮断が効く根拠

`cloudposse/elasticache-redis` モジュールで ingress を作っているのはこの `additional_security_group_rules` だけで、他に許可ルールはありません。実際の SG を確認しました。

```
sg-02fee26c7df6fef7d (dreamkast-prod-redis--wWVC-...)
  ingress: 6379/tcp
    10.110.0.0/20, 10.110.16.0/20, 10.110.32.0/20   (private subnet)
    10.110.48.0/20, 10.110.64.0/20, 10.110.80.0/20  (public subnet)
```

private / public 各 3 CIDR の計 6 件のみで、これらは上記の 2 ブロックが生成したものです。空にすれば egress だけが残り、誰も 6379 に到達できなくなります。

## ⚠️ apply 前に必ず plan を確認してください

`dreamkast_infra` には terraform の CI がありません（`.github/workflows/terraform.yml` を呼んでいるのは `broadcast_switcher` のみ）。plan / apply は手動実行になります。

**加えて、`dreamkast_infra/prod` には既存のドリフトがあります。**

- `local.mysql_major_version = "8.0"` / `mysql_minor_version = "42"` に対し、実インスタンスは **MySQL 8.4.9**
- アタッチされているパラメータグループも実体は `dreamkast-prod-rds-parametergroup-mysql84` で、terraform が生成する名前と一致しない

このまま apply すると **RDS に意図しない変更が入る可能性があります**。plan の出力を必ず確認し、Redis の SG 以外の差分が出る場合は `-target` で絞るか、先にドリフトを解消してください。

## リリース状況（参考）

| | 状態 |
|---|---|
| prod | `dreamkast-prod-dk:352` (`release-v4.20.0`)、rollout COMPLETED、`initdb` exitCode=0、HTTP 200 |
| stg | デプロイ済み。redis を 0 台にした状態でログイン・リロード成功 |
| ElastiCache `CurrConnections` | リリース前のベースラインは平均 5.2 / 最大 6.0。現在 0 への低下を監視中 |

`CurrConnections` が 0 に張り付いていることを確認してからマージするのが安全です。

## この後

一定期間問題が無ければ、`module "elasticache-redis"` ごと削除します。あわせて dreamkast-infra 側の `internalEndpoints.redis` / 各 task-def の `REDIS_URL` / `ecspresso/stg/redis/` / `template-dk/redis/` も撤去します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LiZdLcEGBjBSTkbhYPSW4N
